### PR TITLE
Add additional properties to dump

### DIFF
--- a/main.go
+++ b/main.go
@@ -125,8 +125,8 @@ func getProperties(msg amqp.Delivery) map[string]interface{} {
 		"reply_to":         msg.ReplyTo,
 		"type":             msg.Type,
 		"user_id":          msg.UserId,
-		"exchange":			msg.Exchange,
-		"routing_key":		msg.RoutingKey,
+		"exchange":         msg.Exchange,
+		"routing_key":      msg.RoutingKey,
 	}
 
 	if !msg.Timestamp.IsZero() {

--- a/main.go
+++ b/main.go
@@ -125,6 +125,8 @@ func getProperties(msg amqp.Delivery) map[string]interface{} {
 		"reply_to":         msg.ReplyTo,
 		"type":             msg.Type,
 		"user_id":          msg.UserId,
+		"exchange":			msg.Exchange,
+		"routing_key":		msg.RoutingKey,
 	}
 
 	if !msg.Timestamp.IsZero() {

--- a/main_test.go
+++ b/main_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	testAmqpURI   = "amqp://guest:guest@127.0.0.1:5672/"
+	testAmqpURI      = "amqp://guest:guest@127.0.0.1:5872/"
 	testQueueName    = "test-rabbitmq-dump-queue"
 	testExchangeName = "test-rabbitmq-dump-exchange"
 	testRoutingKey   = "test-rabbitmq-dump-routing-key"

--- a/main_test.go
+++ b/main_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	testAmqpURI      = "amqp://guest:guest@127.0.0.1:5872/"
+	testAmqpURI      = "amqp://guest:guest@127.0.0.1:5672/"
 	testQueueName    = "test-rabbitmq-dump-queue"
 	testExchangeName = "test-rabbitmq-dump-exchange"
 	testRoutingKey   = "test-rabbitmq-dump-routing-key"


### PR DESCRIPTION
Messages routed through an exchange carry additional properties (exchange, routing_key). 

In some scenarios these information are needed to check the message flow, type or even to re-publish the message.

This fixes https://github.com/dubek/rabbitmq-dump-queue/issues/13

![image](https://user-images.githubusercontent.com/7137845/73431433-b3b25c00-4340-11ea-9cd5-c6c0ccbd616e.png)
